### PR TITLE
Add missing `-lm` flag to compile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-FLAGS = -I./deps/linenoise -I./deps/sds
+FLAGS = -I./deps/linenoise -I./deps/sds -lm
 PREFIX?=/usr/local
 
 default: clac


### PR DESCRIPTION
It is needed to link the math library.