### PR TITLE
Output precision, asin acos atan atan2, typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ Pop the value `a` and push its cosine.
 `tan`
 Pop the value `a` and push its tangent.
 
+`asin`
+Pop the value `a` and push its arc sine.
+
+`acos`
+Pop the value `a` and push its arc cosine.
+
+`atan`
+Pop the value `a` and push its arc tangent.
+
+`atan2`
+Pop two values `a` and `b` and push the arc tangent of `b / a`,
+using the signs of `a` and `b` to determine the quadrant.
+
 ### Summation
 
 `sum`

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ represented by the letter `a`, while the second value popped is
 represented by the letter `b`. For example, if the stack is composed
 of the number `1`, `2` and `3` (with `3` at the top of the stack),
 when we describe the sum then `a` will be `3` and `b` will be `2`.
-It is important to note that substraction and division invert the
-order of the arguments before peforming the operation: with `1`,
+It is important to note that subtraction and division invert the
+order of the arguments before performing the operation: with `1`,
 `2` and `3` in the stack, when you type `-` it will pop the values
 `3` and `2` and push the result of `2 - 3`. This is in the tradition
 of other postfix calculators and programming languages.
@@ -61,16 +61,16 @@ Here's a description of the available commands:
 
 ### Arithmetic operations
 
-`+` 
+`+`
 Pop two values `a` and `b` and push the result of `a + b`.
 
-`-` 
+`-`
 Pop two values `a` and `b` and push the result of `b - a`.
 
-`*` 
+`*`
 Pop two values `a` and `b` and push the result of `a * b`.
 
-`/` 
+`/`
 Pop two values `a` and `b` and push the result of `b / a`.
 
 ### Modulo operation
@@ -81,31 +81,31 @@ division of `b` by `a`.
 
 ### Exponentiation
 
-`^` 
+`^`
 Pop two values `a` and `b` and push the result of `b ^ a`.
 
 ### Logarithm
 
-`ln` 
+`ln`
 Pop the value `a` and push its natural logarithm.
 
-`log` 
+`log`
 Pop the value `a` and push its logarithm to base 10.
 
 ### Factorial
 
-`!` 
+`!`
 Pop the value `a` and push its factorial.
 
 ### Trigonometry
 
-`sin` 
+`sin`
 Pop the value `a` and push its sine.
 
-`cos` 
+`cos`
 Pop the value `a` and push its cosine.
 
-`tan` 
+`tan`
 Pop the value `a` and push its tangent.
 
 ### Summation
@@ -120,15 +120,15 @@ their sum.
 ### Rounding
 
 `ceil`
-Pop the value `a` and push smallest integral value greater than or
+Pop the value `a` and push the smallest integer value greater than or
 equal to `a`.
 
 `floor`
-Pop the value `a` and push largest integral value less than or equal
-to `a`.
+Pop the value `a` and push the largest integer value less than or
+equal to `a`.
 
 `round`
-Pop the value `a` and push integral value nearest to `a`.
+Pop the value `a` and push the integer value closest to `a`.
 
 ### Absolute value
 
@@ -137,7 +137,7 @@ Pop the value `a` and push the non-negative value of `a`.
 
 ### Stack manipulation
 
-`swap` 
+`swap`
 Pop two values `a` and `b` and push the values `a`, `b`.
 
 `dup`
@@ -154,9 +154,9 @@ Remove the top of the stack.
 Remove all the elements in the stack.
 
 `count`
-Push the the number of items in the stack.
+Push the number of items in the stack.
 
-`_` 
+`_`
 Push on the stack the result of the last operation.
 
 ### Stashing
@@ -208,7 +208,7 @@ Words are defined as aliases, with one alias on each line. Empty
 lines are ignored. Here are some examples:
 
 ```shell
-pi 3.141592
+pi 3.14159265358979323846
 tau "pi 2 *"
 sqrt "0.5 ^"
 ```
@@ -229,7 +229,7 @@ User defined words can be used as if they were built-in commands:
 
 ```shell
 $ clac "42 dup * pi *"
-5541.76
+5541.76944093239
 ```
 
 ### How to list defined words

--- a/clac.1
+++ b/clac.1
@@ -20,8 +20,8 @@ stack changes are reflected immediately.
 .Pp
 In a stack-based postfix calculator, entering a number pushes it
 on a stack, and arithmetic operations pop their arguments from the
-stack and push the result. As all the operations take a fix number
-of arguments, there's no room for ambiguity: parenthesis and operator
+stack and push the result. As all the operations take a fixed number
+of arguments, there's no room for ambiguity: parentheses and operator
 precedence are not needed. Postfix notation is also known as reverse
 Polish notation, or RPN.
 .
@@ -61,7 +61,7 @@ Pop two values `a` and `b` and push the result of `b - a`.
 .It Ic *
 Pop two values `a` and `b` and push the result of `a * b`.
 .
-.It Ic / 
+.It Ic /
 Pop two values `a` and `b` and push the result of `b / a`.
 .El
 .
@@ -105,6 +105,15 @@ Pop the value `a` and push its sine.
 Pop the value `a` and push its cosine.
 .It Ic tan
 Pop the value `a` and push its tangent.
+.It Ic asin
+Pop the value `a` and push its arc sine.
+.It Ic acos
+Pop the value `a` and push its arc cosine.
+.It Ic atan
+Pop the value `a` and push its arc tangent.
+.It Ic atan2
+Pop two values `a` and `b` and push the arc tangent of `b / a`
+using the signs of `a` and `b` to determine the quadrant.
 .El
 .
 .Ss Summation
@@ -121,13 +130,13 @@ their sum.
 .
 .Bl -tag -width Fl
 .It Ic ceil
-Pop the value `a` and push smallest integral value greater than or
+Pop the value `a` and push the smallest integer value greater than or
 equal to `a`.
 .It Ic floor
-Pop the value `a` and push largest integral value less than or equal
-to `a`.
+Pop the value `a` and push the largest integer value less than or
+equal to `a`.
 .It Ic round
-Pop the value `a` and push integral value nearest to `a`.
+Pop the value `a` and push the integer value closest to `a`.
 .El
 .
 .Ss Absolute value
@@ -152,7 +161,7 @@ Remove the top of the stack.
 .It Ic clear
 Remove all the elements in the stack.
 .It Ic count
-Push the the number of items in the stack.
+Push the number of items in the stack.
 .It Ic _
 Push on the stack the result of the last operation.
 .El
@@ -212,7 +221,7 @@ If set, clac will search for
 Words are defined as aliases, with one alias on each line. Empty
 lines are ignored. Here are some examples:
 .Pp
-.Dl Sy pi No 3.141592
+.Dl Sy pi No 3.14159265358979323846
 .Dl Sy tau Qq "pi 2 *"
 .Dl Sy sqrt Qq "0.5 ^"
 .Pp
@@ -233,7 +242,7 @@ and start clac, we will get this error message:
 User defined words can be used as if they were built-in commands:
 .Pp
 .Dl $ clac Qq "42 dup * pi *"
-.Dl Sy 5541.76
+.Dl Sy 5541.76944093239
 .
 .Ss How to list defined words
 .

--- a/clac.1
+++ b/clac.1
@@ -112,7 +112,7 @@ Pop the value `a` and push its arc cosine.
 .It Ic atan
 Pop the value `a` and push its arc tangent.
 .It Ic atan2
-Pop two values `a` and `b` and push the arc tangent of `b / a`
+Pop two values `a` and `b` and push the arc tangent of `b / a`,
 using the signs of `a` and `b` to determine the quadrant.
 .El
 .

--- a/clac.c
+++ b/clac.c
@@ -37,12 +37,13 @@
 #include "linenoise.h"
 #include "sds.h"
 
-/* UI */  
+/* UI */
 #define HINT_COLOR 33
-#define OUTPUT_FMT "\x1b[33m= %g\x1b[0m\n"
+#define NUMBER_FMT "%.15g"
+#define OUTPUT_FMT "\x1b[33m= " NUMBER_FMT "\x1b[0m\n"
 #define WORDEF_FMT "%s \x1b[33m\"%s\"\x1b[0m\n"
 
-/* Config */  
+/* Config */
 #define BUFFER_MAX 1024
 #define WORDS_FILE "clac/words"
 #define CAPACITY   0xFF
@@ -54,7 +55,7 @@
 #define isempty(S) ((S)->top == 0)
 
 /* Arithmetic */
-#define modulo(A, B) (A - B * floor(A / B))
+#define modulo(A, B) ((A) - (B) * floor((A) / (B)))
 
 typedef struct stack {
 	double items[CAPACITY];
@@ -342,6 +343,24 @@ static void process(sds word) {
 		if (count(s0) > 0) {
 			push(s0, tan(pop(s0)));
 		}
+	} else if (!strcasecmp(word, "asin")) {
+		if (count(s0) > 0) {
+			push(s0, asin(pop(s0)));
+		}
+	} else if (!strcasecmp(word, "acos")) {
+		if (count(s0) > 0) {
+			push(s0, acos(pop(s0)));
+		}
+	} else if (!strcasecmp(word, "atan")) {
+		if (count(s0) > 0) {
+			push(s0, atan(pop(s0)));
+		}
+	} else if (!strcasecmp(word, "atan2")) {
+		if (count(s0) > 1) {
+			a = pop(s0);
+			b = pop(s0);
+			push(s0, atan2(b, a));
+		}
 	} else if (!strcasecmp(word, "ln")) {
 		if (count(s0) > 0) {
 			push(s0, log(pop(s0)));
@@ -430,14 +449,14 @@ static char *hints(const char *input, int *color, int *bold) {
 	result = sdscat(result, " ");
 
 	for (i = 0; i < count(s0); i++) {
-		result = sdscatprintf(result, " %g", s0->items[i]);
+		result = sdscatprintf(result, " " NUMBER_FMT, s0->items[i]);
 	}
 
 	if (!isempty(s1)) {
 		result = sdscat(result, " ⋮");
 
 		for (i = s1->top-1; i > -1; i--) {
-			result = sdscatprintf(result, " %g", s1->items[i]);
+			result = sdscatprintf(result, " " NUMBER_FMT, s1->items[i]);
 		}
 	}
 
@@ -478,7 +497,7 @@ int main(int argc, char **argv) {
 		eval(argv[1]);
 
 		while (count(s0) > 0) {
-			printf("%g\n", pop(s0));
+			printf(NUMBER_FMT "\n", pop(s0));
 		}
 
 		exit(0);


### PR DESCRIPTION
The output format was %g, which is equivalent to %.6g and is good for floats, but the code uses doubles, which have at least 15 digits of precision. Therefore the output format is %.15g now.
The inverse trigonometric functions were missing but are important.
In the example words file, the value of pi has been set to its full double precision, by taking it from math.h
On a personal note, I love clac because it takes me back to the first calculator I owned and programmed, the HP-67!