### PR TITLE
erf (Gauss error function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ Pop the value `a` and push its arc tangent.
 Pop two values `a` and `b` and push the arc tangent of `b / a`,
 using the signs of `a` and `b` to determine the quadrant.
 
+### Error function
+
+`erf`
+Pop the value `a` and push its error function.
+
 ### Summation
 
 `sum`

--- a/clac.1
+++ b/clac.1
@@ -116,6 +116,13 @@ Pop two values `a` and `b` and push the arc tangent of `b / a`,
 using the signs of `a` and `b` to determine the quadrant.
 .El
 .
+.Ss Error function
+.
+.Bl -tag -width Fl
+.It Ic erf
+Pop the value `a` and push its error function.
+.El
+.
 .Ss Summation
 .
 .Bl -tag -width Fl

--- a/clac.c
+++ b/clac.c
@@ -369,6 +369,10 @@ static void process(sds word) {
 		if (count(s0) > 0) {
 			push(s0, log10(pop(s0)));
 		}
+	} else if (!strcasecmp(word, "erf")) {
+		if (count(s0) > 0) {
+			push(s0, erf(pop(s0)));
+		}
 	} else if (!strcasecmp(word, "!")) {
 		if (count(s0) > 0) {
 			a = pop(s0);


### PR DESCRIPTION
The erf (error function) completes the set of useful mathematical functions that cannot be derived from other words. I like the idea to leave out all the functions that can be described in terms of the available words, but the erf is not one of these. The erf is an important function in statistics, where it is linearly related to the normal (i.e., Gaussian) cumulative distribution function. See also the "68–95–99.7 rule".
Sorry for the last minute addition. I hope you didn't build the release yet.